### PR TITLE
:ambulance: Fix installing mdns node package

### DIFF
--- a/homebridge/Dockerfile
+++ b/homebridge/Dockerfile
@@ -1,4 +1,5 @@
 FROM %%BASE_IMAGE%%
+#FROM homeassistant/armhf-base:latest
 MAINTAINER Franck Nijhof <frenck@geekchimp.com>
 
 # Add env
@@ -8,18 +9,21 @@ ENV LANG="C.UTF-8"
 COPY files/run.sh /
 
 # Setup base
-RUN apk add --no-cache jq git python make g++ libffi-dev openssl-dev openrc dbus \
+RUN apk add --no-cache jq git python make g++ libffi-dev openssl-dev dbus \
       avahi-compat-libdns_sd avahi-dev avahi-tools avahi-ui-tools \
-      nodejs-current nodejs-current-npm yarn && \
+      nodejs-current yarn && \
     mkdir -p /var/run/dbus && \
     mkdir -p /var/run/avahi-daemon && \
     chown messagebus:messagebus /var/run/dbus && \
     chown avahi:avahi /var/run/avahi-daemon && \
-    yarn global add node-gyp && \
-    yarn global add homebridge@0.4.22 && \
-    yarn global add homebridge-homeassistant && \
-    npm cache clean && \
+    yarn global add npm && \
     yarn cache clean && \
+    apk del yarn && \
+    npm set unsafe-perm true && \
+    npm -g install \
+      node-gyp \
+      homebridge \
+      homebridge-homeassistant && \
     chmod a+x /run.sh
 
 # Copy configuration files

--- a/homebridge/config.json
+++ b/homebridge/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Homebridge",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "slug": "homebridge",
   "description": "HomeKit support for your Home Assistant instance using Homebridge",
   "url": "https://github.com/hassio-addons/addon-homebridge",

--- a/homebridge/files/run.sh
+++ b/homebridge/files/run.sh
@@ -177,7 +177,7 @@ generate_homekit_pin() {
 #   None
 # ------------------------------------------------------------------------------
 apply_hap_nodejs_ipv6_hotfix() {
-  local eventedhttp_file='/usr/local/share/.config/yarn/global/node_modules/hap-nodejs/lib/util/eventedhttp.js'
+  local eventedhttp_file='/usr/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/util/eventedhttp.js'
 
   display_status_message 'Applying HAP NodeJS IPV6 HOTFIX'
   command patch $eventedhttp_file <<PATCH
@@ -237,7 +237,7 @@ install_plugins() {
   do
     display_status_message "Installing Homebridge plugin $plugin"
 
-    command yarn global add "$plugin" || display_error_message \
+    command npm install --unsafe-perm -g "$plugin" || display_error_message \
       "Failed installing Homebridge plugin $plugin" $EX_PLUGIN_FAILED
   done
 }


### PR DESCRIPTION
Some Homebridge plugins are depending on the `mdns` node package.
This requires npm to run in unsafe-perm mode.

Fixes hassio-addons/repository#6