### PR TITLE
Connect to HA API via Hass.io proxy by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 
 - Made git available by default #44
 
+### Changed
+
+- Use the Hass.io to Home Assistant proxy by default
+
 ## [v2.0.0] (2017-10-20)
 
 [Full Changelog][v1.0.3-v2.0.0]

--- a/README.md
+++ b/README.md
@@ -248,11 +248,10 @@ http://0pointerde/avahi-compat?s=libdns_sd&e=nodejs&f=DNSServiceRegister
 ### Homebridge cannot connect or login to Home Assistant
 
 Please be sure to set the `host` and `password` parameters in the
-`/config/homebridge/config.json` file.
-Normally `http://homeassistant:8123` should be a sufficient `host` to use when
-running hass.io. The `password` is left empty by default, however, if a
-password protects your Home Assistant instance, you might also need to
-set the `password` option.
+`/config/homebridge/config.json` file. 
+
+We recommend using `http://hassio/homeassistant` as the `host` with an 
+empty `password`, which allows Homebridge to talk to Home Assistant directly.
 
 ### My iOS App Cannot Find Homebridge/Home Assistant
 

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ http://0pointerde/avahi-compat?s=libdns_sd&e=nodejs&f=DNSServiceRegister
 ### Homebridge cannot connect or login to Home Assistant
 
 Please be sure to set the `host` and `password` parameters in the
-`/config/homebridge/config.json` file. 
+`/config/homebridge/config.json` file.
 
-We recommend using `http://hassio/homeassistant` as the `host` with an 
+We recommend using `http://hassio/homeassistant` as the `host` with an
 empty `password`, which allows Homebridge to talk to Home Assistant directly.
 
 ### My iOS App Cannot Find Homebridge/Home Assistant

--- a/homebridge/rootfs/root/homebridge-config.json
+++ b/homebridge/rootfs/root/homebridge-config.json
@@ -11,7 +11,7 @@
     {
       "platform": "HomeAssistant",
       "name": "HomeAssistant",
-      "host": "http://homeassistant:8123",
+      "host": "http://hassio/homeassistant",
       "password": "",
       "default_visibility": "visible",
       "supported_types": [


### PR DESCRIPTION
# Proposed Changes

Improves the initial setup for users to use the new Home Assistant proxy offered by Hass.io.
This allows for direct & unauthenticated access from this add-on the Home Assistant API.

This would remove the need for the user to add a password to their Homebridge configuration and adds to the "working-out-of-the-box" principle.

## Related Issues

None