### PR TITLE
Upgrades homebridge-homeassistant to v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 ### Changed
 
 - Upgraded NodeJS to 8.x #47
+- Upgraded `homebridge-homeassistant` to v3.0.1
 
 ## [v2.0.1] (2017-10-25)
 

--- a/homebridge/Dockerfile
+++ b/homebridge/Dockerfile
@@ -34,7 +34,7 @@ RUN \
     && npm -g install \
         node-gyp \
         homebridge@0.4.28 \
-        homebridge-homeassistant@2.3.1 \
+        homebridge-homeassistant@3.0.1 \
     \
     && apk del --purge .build-dependencies
 

--- a/homebridge/rootfs/root/homebridge-config.json
+++ b/homebridge/rootfs/root/homebridge-config.json
@@ -28,8 +28,10 @@
         "media_player",
         "remote",
         "scene",
+        "script",
         "sensor",
-        "switch"
+        "switch",
+        "vacuum"
       ],
       "logging": true,
       "verify_ssl": true


### PR DESCRIPTION
# Proposed Changes

- Upgrades `homebridge-homeassistant` to the latest version (v3.0.1).
- Updates the default configuration file to match the above upgrade.

## Related Issues

None