### PR TITLE
Adds option to run Homebridge insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ In some situations, IPv6 might cause more problems then it solves.
 Setting this option to `false`, partially disables IPv6 support causing
 Ahahi and Homebridge to only listen for connections on IPv4
 
+### Option: `insecure`
+
+Allow unauthenticated requests to Homebridge (for easier hacking). Some
+plugins require this as well. Be aware of the possible security implication
+this has.
+
 ### Option: `packages`
 
 Allows you to specify additional [Alpine packages][alpine-packages] to be

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ can change it as well).
 - Errors on startup. The following errors are experienced when starting
   Homebridge and can be safely ignored.
 
-```
+```txt
 *** WARNING *** The program 'nodejs' uses the Apple Bonjour compatibility layer
 of Avahi
 *** WARNING *** Please fix your application to use the native API of Avahi!
@@ -375,6 +375,7 @@ SOFTWARE.
 [aarch64-microbadger]: https://microbadger.com/images/hassioaddons/homebridge-aarch64
 [aarch64-pulls-shield]: https://img.shields.io/docker/pulls/hassioaddons/homebridge-aarch64.svg
 [aarch64-version-shield]: https://images.microbadger.com/badges/version/hassioaddons/homebridge-aarch64.svg
+[alpine-packages]: https://pkgs.alpinelinux.org/
 [amd64-anchore-shield]: https://anchore.io/service/badges/image/2b9a78e147678b80fc0e8c63537c669b803f605555d055fba8fe5bd01a5ea60c
 [amd64-anchore]: https://anchore.io/image/dockerhub/hassioaddons%2Fhomebridge-amd64%3Alatest
 [amd64-arch-shield]: https://img.shields.io/badge/architecture-amd64-blue.svg

--- a/homebridge/config.json
+++ b/homebridge/config.json
@@ -26,6 +26,7 @@
     "avahi_hostname": "",
     "avahi_domainname": "local",
     "enable_ipv6": true,
+    "insecure": false,
     "packages": [],
     "init_commands": [],
     "plugins": []
@@ -36,6 +37,7 @@
     "avahi_hostname": "str",
     "avahi_domainname": "str",
     "enable_ipv6": "bool",
+    "insecure": "bool",
     "packages": ["str"],
     "init_commands": ["str"],
     "plugins": ["str"]

--- a/homebridge/rootfs/etc/services.d/homebridge/run
+++ b/homebridge/rootfs/etc/services.d/homebridge/run
@@ -6,6 +6,8 @@
 # shellcheck disable=SC1091
 source /usr/lib/hassio-addons/base.sh
 
+declare -a homebridge_options
+
 # Wait for Avahi to become available
 s6-svwait -u -t 5000 /var/run/s6/services/avahi
 
@@ -13,8 +15,14 @@ s6-svwait -u -t 5000 /var/run/s6/services/avahi
 # Avahi might need some time.
 sleep 5
 
-if hass.debug; then
-  exec homebridge -D -U /config/homebridge/
-else
-  exec homebridge -U /config/homebridge/
+homebridge_options+=(-U "/config/homebridge")
+
+if hass.config.true 'insecure'; then
+  homebridge_options+=(--insecure)
 fi
+
+if hass.debug; then
+  homebridge_options+=(--debug)
+fi
+
+exec homebridge "${homebridge_options[@]}"


### PR DESCRIPTION
# Proposed Changes

Add the possibility to run Homebridge in insecure mode.
This feature was requested.

## Related Issues

#91